### PR TITLE
Avoid NaNs when gradient is zero in JPEG and PGD attacks

### DIFF
--- a/advex_uar/attacks/jpeg_attack.py
+++ b/advex_uar/attacks/jpeg_attack.py
@@ -66,7 +66,7 @@ class JPEGAttack(AttackWrapper):
             elif self.opt == 'l2':
                 batch_size = pixel_inp.size()[0]
                 grad_norm = torch.norm(grad.view(batch_size, -1), 2.0, dim=1)
-                normalized_grad = grad / grad_norm[:, None]                
+                normalized_grad = grad / (grad_norm[:, None] + 1e-8)
                 cat_var.data = cat_var.data + step_size[:, None] * normalized_grad
                 l2_delta = torch.norm(cat_var.data.view(batch_size, -1), 2.0, dim=1)
                 proj_scale = torch.min(torch.ones_like(l2_delta, device='cuda'), base_eps / l2_delta)

--- a/advex_uar/attacks/pgd_attack.py
+++ b/advex_uar/attacks/pgd_attack.py
@@ -56,7 +56,7 @@ class PGDAttack(AttackWrapper):
             elif self.norm == 'l2':
                 batch_size = delta.data.size()[0]
                 grad_norm = torch.norm(grad.view(batch_size, -1), 2.0, dim=1)
-                normalized_grad = grad / grad_norm[:, None, None, None]                
+                normalized_grad = grad / (grad_norm[:, None, None, None] + 1e-8)
                 delta.data = delta.data + step_size[:, None, None, None] * normalized_grad
                 l2_delta = torch.norm(delta.data.view(batch_size, -1), 2.0, dim=1)
                 # Check for numerical instability


### PR DESCRIPTION
In the current implementation of the L2 PGD and JPEG attacks, if the gradient from the network is zero for some inputs, then those inputs will be turned to NaNs because of a divide-by-zero. A common solution to this problem is to add a small positive value to the gradient norm before normalizing by it; here I've used 1e-8.